### PR TITLE
Add ability to override number of compilation workers

### DIFF
--- a/templates/router.yml
+++ b/templates/router.yml
@@ -9,7 +9,7 @@ releases:
 compilation:
   network: router1
   reuse_compilation_vms: true
-  workers: 6
+  workers: (( iaas_settings.compilation_workers || 6))
   cloud_properties: (( iaas_settings.compilation_cloud_properties ))
 
 update:


### PR DESCRIPTION
Some Iaas fail with too large concurrent compilation workers. This enables configuring them without manually patching the generated manifest.

